### PR TITLE
159965445 Add pagination support for articles

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
     "coveralls": "^3.0.2",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.6.0",
+<<<<<<< HEAD
     "expect": "^23.6.0",
+=======
+    "fetch-mock": "^7.2.0",
+>>>>>>> [Feature #159965445] Add pagination support for articles
     "history": "^4.7.2",
     "materialize-css": "^1.0.0",
     "moment-timezone": "^0.5.21",
@@ -31,6 +35,7 @@
     "react-hot-loader": "^4.3.11",
     "react-materialize": "^2.4.6",
     "react-moment": "^0.8.1",
+    "react-paginate": "^5.2.4",
     "react-placeholder": "^3.0.1",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,8 @@
     "coveralls": "^3.0.2",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.6.0",
-<<<<<<< HEAD
     "expect": "^23.6.0",
-=======
     "fetch-mock": "^7.2.0",
->>>>>>> [Feature #159965445] Add pagination support for articles
     "history": "^4.7.2",
     "materialize-css": "^1.0.0",
     "moment-timezone": "^0.5.21",

--- a/src/containers/Articles/Article/largArticle.js
+++ b/src/containers/Articles/Article/largArticle.js
@@ -44,7 +44,14 @@ class MainArticle extends Component {
     }
     const user = localStorage.getItem('user');
     // eslint-disable-next-line
-    const author = mainArticle.payload.author;
+    let author;
+    if (mainArticle.payload.author) {
+      author = mainArticle.payload.author.username;
+    }
+    let showEditbutton = false;
+    if (author === user) {
+      showEditbutton = true;
+    }
     return (
       <div>
         <div className="tag-list">
@@ -58,20 +65,19 @@ class MainArticle extends Component {
             : null}
         </div>
         <UsrInfo />
-        {user === author ? (
-          <button type="button" onClick={this.editClickedHanlder} className="button">
-            Edit
-          </button>
-        ) : null}
-        <button type="button" onClick={this.editClickedHanlder} className="button">
-          Edit
-        </button>
-        {mainArticle.payload.slug !== undefined && (
-          <Rating
-            slug={mainArticle.payload.slug}
-            average_rating={mainArticle.payload.average_ratings}
-          />
-        )}
+        {
+          (showEditbutton)
+            ? (
+              <button type="button" onClick={this.editClickedHanlder} className="button">
+                        Edit
+              </button>)
+            : null
+        }
+
+        <Rating
+          slug={mainArticle.payload.slug}
+          average_rating={mainArticle.payload.average_ratings}
+        />
         <div className="main-article">
           {this.renderArticleHandler()}
           <div>

--- a/src/containers/Articles/Create/reducer.test.js
+++ b/src/containers/Articles/Create/reducer.test.js
@@ -1,0 +1,45 @@
+import * as actions from './actions';
+import publishArticleReducer from './reducer';
+
+const initialState = {
+  payload: {},
+  publishing: false,
+  success: false,
+  failure: false,
+  error: undefined,
+};
+
+describe('Test for New Article Create Reducer', () => {
+  it('should should set publish to true on successful publishing', () => {
+    const action = actions.articleFetch();
+    const newState = publishArticleReducer(initialState, action);
+    expect(Object.keys(newState).length).toEqual(5);
+    expect(newState.publishing).toBe(true);
+  });
+  it('should set success True when article is published successfully', () => {
+    const payload = {
+      data: {
+        articles: {
+          title: 'Article DAta',
+          body: 'Article Body',
+          description: 'Article Description',
+        },
+      },
+    };
+    const action = actions.articleSuccess(payload);
+
+    const newState = publishArticleReducer(initialState, action);
+
+    expect(Object.keys(newState).length).toEqual(5);
+    expect(newState.success).toBe(true);
+  });
+  it('should set failed to true incase of failure', () => {
+    const errors = { errors: { error: ['Article not found'] } };
+    const action = actions.articleFailure(errors);
+
+    const newState = publishArticleReducer(initialState, action);
+
+    expect(Object.keys(newState).length).toEqual(5);
+    expect(newState.failure).toBe(true);
+  });
+});

--- a/src/containers/Articles/Create/userInfo.js
+++ b/src/containers/Articles/Create/userInfo.js
@@ -15,6 +15,7 @@ class UsrInfo extends Component {
   render() {
     const { viewProfileReducer, username } = this.props;
     const { profile } = viewProfileReducer.loggedInUser;
+    localStorage.setItem('user_img', profile.image);
 
     return (
       <div style={{ width: '70%', marginLeft: '20%', marginTop: '2%' }}>

--- a/src/containers/Articles/Read/actions.js
+++ b/src/containers/Articles/Read/actions.js
@@ -9,12 +9,10 @@ export const articleFailure = errors => ({ type: ARTICLE_FAILURE, errors });
 
 export const articleFetch = () => ({ type: GET_ARTICLES });
 
-const getArticles = () => (dispatch) => {
+export const getArticles = (limit, offset) => (dispatch) => {
   dispatch(articleFetch());
-  const MAIN_URL = ` ${BACKEND_URL}api/articles`;
+  const MAIN_URL = ` ${BACKEND_URL}api/articles?limit=${limit}&offset=${offset}`;
   axios.get(MAIN_URL)
     .then(res => dispatch(articleSuccess(res)))
     .catch(err => dispatch(articleFailure(err)));
 };
-
-export default getArticles;

--- a/src/containers/Articles/Read/actions.test.js
+++ b/src/containers/Articles/Read/actions.test.js
@@ -1,0 +1,47 @@
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import fetchMock from 'fetch-mock';
+
+import {
+  articleFetch, articleSuccess, articleFailure, getArticles,
+} from './actions';
+import * as types from './constants';
+import articleTestData from '../../../utils/articleData';
+import getActions from '../../../utils/getActions';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('Read Actions', () => {
+  afterEach(() => {
+    fetchMock.reset();
+    fetchMock.restore();
+  });
+  it('should fetch Articles', () => {
+    const expectedAction = { type: types.GET_ARTICLES };
+    expect(articleFetch()).toEqual(expectedAction);
+  });
+
+  it('should return errors incase of failures', () => {
+    const errors = articleTestData.articleError;
+    const expectedAction = {
+      type: types.ARTICLE_FAILURE,
+      errors,
+    };
+    expect(articleFailure(errors)).toEqual(expectedAction);
+  });
+
+  it('should return success if articles payload was received', () => {
+    const payload = articleTestData.article;
+    const expectedAction = {
+      type: types.ARTICLE_SUCCESS,
+      payload,
+    };
+    expect(articleSuccess(payload)).toEqual(expectedAction);
+  });
+  it('should dispatch fetch action', async () => {
+    const store = mockStore();
+    store.dispatch(getArticles());
+    expect(await getActions(store, types.GET_ARTICLES)).toEqual({ type: types.GET_ARTICLES });
+  });
+});

--- a/src/containers/Articles/Read/aside.js
+++ b/src/containers/Articles/Read/aside.js
@@ -4,7 +4,7 @@ import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
-import getArticles from './actions';
+import { getArticles } from './actions';
 import '../../../styles/styles.css';
 import { extractDescription } from './filterArticles';
 

--- a/src/containers/Articles/Read/index.js
+++ b/src/containers/Articles/Read/index.js
@@ -2,20 +2,47 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
+import ReactPaginate from 'react-paginate';
+import axios from 'axios';
 
 import '../../../styles/styles.css';
-import getArticles from './actions';
+import { getArticles } from './actions';
 import Aside from './aside';
 import ArticleComponent from './articleComponents';
 import { extractDescription } from './filterArticles';
 import Tags from '../../../components/tags/index';
-
+import { BACKEND_URL } from '../../../utils/config';
 import NotFound from '../../../components/NotFound';
 
 class ReadArticle extends Component {
+  state = {
+    offset: 0,
+    perPage: 10,
+    pageCount: 1,
+  }
+
   componentDidMount() {
     const { getAllArticles } = this.props;
-    getAllArticles();
+    const { perPage, offset } = this.state;
+    getAllArticles(perPage, offset);
+    getAllArticles(perPage, offset);
+    axios.get(`${BACKEND_URL}api/articles`)
+      .then((res) => {
+        const pageCount = Math.ceil(res.data.articles.count / res.data.articles.results.length);
+        console.log(res.data.articles.results.length);
+        this.setState({ pageCount });
+      })
+      .catch(err => console.log(err));
+  }
+
+  handlePageClick = (data) => {
+    const { selected } = data;
+    const { perPage } = this.state;
+    const { getAllArticles } = this.props;
+    const offset = Math.ceil(selected * perPage);
+    this.setState({ offset }, () => {
+      getAllArticles(perPage, offset);
+    });
   }
 
   renderArticleHandler = () => {
@@ -50,11 +77,31 @@ class ReadArticle extends Component {
   };
 
   render() {
+    const { pageCount } = this.state;
     return (
-      <div className="article-landing-page" style={{ marginLeft: 50, marginBottom: '50%' }}>
-        <Aside />
-        <Tags />
-        { this.renderArticleHandler()}
+      <div>
+        <div className="article-landing-page" style={{ marginLeft: 50, marginBottom: '50%' }}>
+          <Aside />
+          <Tags />
+          { this.renderArticleHandler()}
+        </div>
+        <div className="pagination-lable">
+          <ReactPaginate
+            previousLabel="previous"
+            nextLabel="next"
+            breakLabel={<a href="">...</a>}
+            breakClassName="break-me"
+            pageCount={pageCount}
+            marginPagesDisplayed={2}
+            pageRangeDisplayed={5}
+            onPageChange={this.handlePageClick}
+            containerClassName="pagination"
+            activeClassName="page-item active"
+            disabledClassName="page-item disabled"
+            pageClassName="page-item"
+            extraAriaContext="Page navigation example"
+          />
+        </div>
       </div>
     );
   }

--- a/src/containers/Articles/Read/index.js
+++ b/src/containers/Articles/Read/index.js
@@ -29,9 +29,9 @@ class ReadArticle extends Component {
     axios.get(`${BACKEND_URL}api/articles`)
       .then((res) => {
         const pageCount = Math.ceil(res.data.articles.count / res.data.articles.results.length);
-        console.log(res.data.articles.results.length);
         this.setState({ pageCount });
       })
+      // eslint-disable-next-line
       .catch(err => console.log(err));
   }
 

--- a/src/containers/Articles/Read/index.js
+++ b/src/containers/Articles/Read/index.js
@@ -30,9 +30,7 @@ class ReadArticle extends Component {
       .then((res) => {
         const pageCount = Math.ceil(res.data.articles.count / res.data.articles.results.length);
         this.setState({ pageCount });
-      })
-      // eslint-disable-next-line
-      .catch(err => console.log(err));
+      });
   }
 
   handlePageClick = (data) => {

--- a/src/containers/Articles/Read/index.js
+++ b/src/containers/Articles/Read/index.js
@@ -25,7 +25,6 @@ class ReadArticle extends Component {
     const { getAllArticles } = this.props;
     const { perPage, offset } = this.state;
     getAllArticles(perPage, offset);
-    getAllArticles(perPage, offset);
     axios.get(`${BACKEND_URL}api/articles`)
       .then((res) => {
         const pageCount = Math.ceil(res.data.articles.count / res.data.articles.results.length);

--- a/src/containers/Articles/Read/reducer.test.js
+++ b/src/containers/Articles/Read/reducer.test.js
@@ -1,0 +1,46 @@
+import * as actions from './actions';
+import getArticleReducer from './reducer';
+
+const initialState = {
+  all_articles: [],
+  loading: false,
+  failed: false,
+  success: false,
+};
+
+describe('Test for Article Read Reducer', () => {
+  it('should should set loading true when getting articles', () => {
+    const action = actions.articleFetch();
+    const newState = getArticleReducer(initialState, action);
+    expect(Object.keys(newState).length).toEqual(4);
+    expect(newState.loading).toBe(true);
+  });
+  it('should set success True when successfully received payload', () => {
+    const payload = {
+      data: {
+        articles: {
+          results: {
+            title: 'Article DAta',
+            body: 'Article Body',
+            description: 'Article Description',
+          },
+        },
+      },
+    };
+    const action = actions.articleSuccess(payload);
+
+    const newState = getArticleReducer(initialState, action);
+
+    expect(Object.keys(newState).length).toEqual(4);
+    expect(newState.success).toBe(true);
+  });
+  it('should set failed to true incase of failure', () => {
+    const errors = { errors: { error: ['Article not found'] } };
+    const action = actions.articleFailure(errors);
+
+    const newState = getArticleReducer(initialState, action);
+
+    expect(Object.keys(newState).length).toEqual(4);
+    expect(newState.failed).toBe(true);
+  });
+});

--- a/src/containers/comments/index.js
+++ b/src/containers/comments/index.js
@@ -36,30 +36,25 @@ class Comments extends Component {
             className="avatar-small"
             alt="User Profile"
             style={{ marginTop: 15 }}
-            src="https://api.adorable.io/avatars/285/abott@adorable.png"
+            src={localStorage.getItem('user_img')}
           />
           <div className="articale-time">
             <p>
               <a href="/">{userName}</a>
             </p>
-            <div className="article-time--details">
-              Time Created
-            </div>
           </div>
         </div>
         <div className="row">
           <form className="col s12">
             <div className="row">
-              <div className="input-field col s12">
-                <textarea id="textarea1" value={inputData} onChange={this.inputCommentHandler} className="materialize-textarea" />
-                {/* eslint-disable-next-line */}
-                <label htmlFor="textarea1">New Comment</label>
+              <div className="input-field col s12 text-area-input-text">
+                <textarea id="textarea1" placeholder="New Comment" value={inputData} onChange={this.inputCommentHandler} className="materialize-textarea" />
               </div>
             </div>
           </form>
         </div>
         {/* eslint-disable-next-line */}
-        <a className="waves-effect waves-light btn" onClick={this.publishCommentHandler}>Publish</a>
+        <a className="waves-effect waves-light btn comment-publish-btn" onClick={this.publishCommentHandler}>Publish</a>
       </div>
     );
   }

--- a/src/styles/scss/base/_settings.scss
+++ b/src/styles/scss/base/_settings.scss
@@ -38,4 +38,4 @@ $comment-grey: #cccccc;
 $color-black: #000000;
 $color-tabs: rgb(160, 160, 160);
 $t-border-b:  rgb(184, 184, 184);
-
+$pagination-gray: #aaaaaa;

--- a/src/styles/scss/components/_comments.scss
+++ b/src/styles/scss/components/_comments.scss
@@ -1,8 +1,17 @@
 @import "../base/settings";
 
 .new-comments {
-  border: 1px solid $comment-grey;
   padding: 2%;
+}
+
+.text-area-input-text {
+  border: 1px solid $comment-grey;
+  border-radius: 2%;
+  padding: 40px;
+}
+
+.comment-publish-btn {
+  float: right;
 }
 
 .display-comments {

--- a/src/styles/scss/components/_pagination.scss
+++ b/src/styles/scss/components/_pagination.scss
@@ -1,0 +1,78 @@
+.pagination-lable {
+    position: absolute;
+    top: 292%;
+    left: 30%;
+    margin-top: 5%;
+}
+
+.pagination{
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+}
+
+.previous>a{
+    text-transform: capitalize;
+    text-decoration: none;
+}
+
+.previous{
+    border-radius: 0.2em;
+    padding: 2px;
+    margin-right: 0.5em;
+    border: 0.04em solid $pagination-gray;
+}
+
+.previous:hover{
+    cursor: pointer;
+    background-color: $color-gray;
+}
+
+.next>a{
+    text-transform: capitalize;
+    text-decoration: none;
+}
+
+.next{
+    border: 0.04em solid $pagination-gray;
+    border-radius: 0.2em;
+    padding: 2px;
+}
+
+.next:hover{
+    cursor: pointer;
+}
+
+.page-item>a{
+    color: rgb(53, 51, 51);
+    text-decoration: none;
+    font-min-size: 2em;
+    margin: 0 !important;
+    padding: 2px;
+}
+
+.page-item {
+    margin-right: 0.5em;
+    border: 0.04em solid $pagination-gray;
+    border-radius: 2px;
+    padding: 2px;
+    cursor: pointer;
+}
+
+.page-item:hover{
+    cursor: pointer;
+}
+
+.active {
+    background-color: #007bff;
+    border-radius: 0.2em !important;
+}
+
+.active> a{
+    color: white;
+
+}
+
+.pagination a:first-child {
+    margin-right: 0.5em;
+}

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -525,6 +525,44 @@ ul#dropdown-share.dropdown-content.social-share li:hover {
   justify-content: flex-start;
   margin-top: 10px; }
 
+.bookmark-articles {
+  font-family: Athelas,'Times New Roman';
+  font-size: 1.3rem; }
+
+.bookmark-title {
+  font-family: Lato;
+  font-weight: bolder; }
+
+.bookmark-articles .row .card-action ul {
+  padding: 0px;
+  margin: 0px; }
+
+.bookmark-articles .row .card-action ul li {
+  display: inline;
+  font-family: Lato;
+  font-size: 0.8em;
+  padding: 0px 10px; }
+
+.bookmark-header {
+  color: red;
+  text-align: center;
+  text-transform: capitalize; }
+
+.bookmark-header-none {
+  color: black;
+  text-align: center;
+  text-transform: capitalize; }
+
+h1 {
+  font-weight: bold; }
+
+.bookmark-link {
+  color: #aaa; }
+
+.bookmark-link:hover {
+  background-color: #ffffff;
+  color: #000000; }
+
 .pagination-lable {
   position: absolute;
   top: 292%;
@@ -588,44 +626,6 @@ ul#dropdown-share.dropdown-content.social-share li:hover {
 
 .pagination a:first-child {
   margin-right: 0.5em; }
-
-.bookmark-articles {
-  font-family: Athelas,'Times New Roman';
-  font-size: 1.3rem; }
-
-.bookmark-title {
-  font-family: Lato;
-  font-weight: bolder; }
-
-.bookmark-articles .row .card-action ul {
-  padding: 0px;
-  margin: 0px; }
-
-.bookmark-articles .row .card-action ul li {
-  display: inline;
-  font-family: Lato;
-  font-size: 0.8em;
-  padding: 0px 10px; }
-
-.bookmark-header {
-  color: red;
-  text-align: center;
-  text-transform: capitalize; }
-
-.bookmark-header-none {
-  color: black;
-  text-align: center;
-  text-transform: capitalize; }
-
-h1 {
-  font-weight: bold; }
-
-.bookmark-link {
-  color: #aaa; }
-
-.bookmark-link:hover {
-  background-color: #ffffff;
-  color: #000000; }
 
 .alert-error {
   color: #a94442;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -524,6 +524,7 @@ ul#dropdown-share.dropdown-content.social-share li:hover {
   display: flex;
   justify-content: flex-start;
   margin-top: 10px; }
+
 .pagination-lable {
   position: absolute;
   top: 292%;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -322,8 +322,15 @@ li.nav-logout {
     top: 90px; }
 
 .new-comments {
-  border: 1px solid #cccccc;
   padding: 2%; }
+
+.text-area-input-text {
+  border: 1px solid #cccccc;
+  border-radius: 2%;
+  padding: 40px; }
+
+.comment-publish-btn {
+  float: right; }
 
 .display-comments {
   margin-top: 6%;
@@ -517,6 +524,69 @@ ul#dropdown-share.dropdown-content.social-share li:hover {
   display: flex;
   justify-content: flex-start;
   margin-top: 10px; }
+.pagination-lable {
+  position: absolute;
+  top: 292%;
+  left: 30%;
+  margin-top: 5%; }
+
+.pagination {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex; }
+
+.previous > a {
+  text-transform: capitalize;
+  text-decoration: none; }
+
+.previous {
+  border-radius: 0.2em;
+  padding: 2px;
+  margin-right: 0.5em;
+  border: 0.04em solid #aaaaaa; }
+
+.previous:hover {
+  cursor: pointer;
+  background-color: #aaa; }
+
+.next > a {
+  text-transform: capitalize;
+  text-decoration: none; }
+
+.next {
+  border: 0.04em solid #aaaaaa;
+  border-radius: 0.2em;
+  padding: 2px; }
+
+.next:hover {
+  cursor: pointer; }
+
+.page-item > a {
+  color: #353333;
+  text-decoration: none;
+  font-min-size: 2em;
+  margin: 0 !important;
+  padding: 2px; }
+
+.page-item {
+  margin-right: 0.5em;
+  border: 0.04em solid #aaaaaa;
+  border-radius: 2px;
+  padding: 2px;
+  cursor: pointer; }
+
+.page-item:hover {
+  cursor: pointer; }
+
+.active {
+  background-color: #007bff;
+  border-radius: 0.2em !important; }
+
+.active > a {
+  color: white; }
+
+.pagination a:first-child {
+  margin-right: 0.5em; }
 
 .bookmark-articles {
   font-family: Athelas,'Times New Roman';

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -10,6 +10,7 @@
 @import "./scss/components/share";
 
 @import "./scss/components/listBookmarks";
+@import "./scss/components/pagination";
 
 .alert-error {
   color: $error-red;

--- a/src/utils/articleData.js
+++ b/src/utils/articleData.js
@@ -1,0 +1,8 @@
+export default {
+  articleError: { article: { detail: 'An article with this slug does not exist.' } },
+  article: {
+    title: 'Article test',
+    body: 'Article Body',
+    articleDescription: 'Article Desc',
+  },
+};

--- a/src/utils/getActions.js
+++ b/src/utils/getActions.js
@@ -1,0 +1,15 @@
+const findAction = (store, type) => store.getActions().find(action => action.type === type);
+
+const getAction = (store, type) => {
+  const action = findAction(store, type);
+  if (action) return Promise.resolve(action);
+
+  return new Promise((resolve) => {
+    store.subscribe(() => {
+      const actions = findAction(store, type);
+      if (actions) resolve(actions);
+    });
+  });
+};
+
+export default getAction;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1732,6 +1732,15 @@ babel-plugin-transform-react-remove-prop-types@0.4.18:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.18.tgz#85ff79d66047b34288c6f7cc986b8854ab384f8c"
   integrity sha512-azed2nHo8vmOy7EY26KH+om5oOcWRs0r1U8wOmhwta+SBMMnmJ4H6yaBZRCcHBtMeWp9AVhvBTL/lpR1kEx+Xw==
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-jest@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
@@ -4181,6 +4190,16 @@ fbjs@^0.8.0, fbjs@^0.8.15:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
+fetch-mock@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-7.2.0.tgz#89b8a0fe30dae806924f76e886fb74e165cb0103"
+  integrity sha512-URZutXz5rsIOGx/8iDIpCrrSaB4nM3TvC+LcsiQmIff/Eo/a/MQG2yZ77tcu4N15FRPAq2bzJlsMN6LfmVQT4Q==
+  dependencies:
+    babel-polyfill "^6.26.0"
+    glob-to-regexp "^0.4.0"
+    path-to-regexp "^2.2.1"
+    whatwg-url "^6.5.0"
+
 figgy-pudding@^3.1.0, figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -4582,6 +4601,11 @@ glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
+
+glob-to-regexp@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz#49bd677b1671022bd10921c3788f23cdebf9c7e6"
+  integrity sha512-fyPCII4vn9Gvjq2U/oDAfP433aiE64cyP/CJjRJcpVGjqqNdioUYn9+r0cSzT1XPwmGAHuTT7iv+rQT8u/YHKQ==
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
   version "7.1.3"
@@ -7895,6 +7919,11 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-to-regexp@^2.2.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
+  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -9101,6 +9130,13 @@ react-moment@^0.8.1:
   resolved "https://registry.yarnpkg.com/react-moment/-/react-moment-0.8.1.tgz#0f60604752fdfa1811d8ebe04ec339d897c9d085"
   integrity sha512-wgOEyIPdda1rYJKqnBsaCsCQl8SvY0L/L52haaoz8ZXb/NgIqUKnxVsjW2nu4/Bz/YAibvyBPsIsW8c+FXQnNQ==
 
+react-paginate@^5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/react-paginate/-/react-paginate-5.2.4.tgz#0a4d6d468ebb1795d0581bd4fc930ad57a86ae14"
+  integrity sha512-va0UxtGtJJih227VhYlo5TYgxXKM6pGmhgDnk8bNCf+R/gjyglk732vEIa8EAC8WLri80WJAvWzBqYYt2tBFug==
+  dependencies:
+    prop-types "^15.6.1"
+
 react-placeholder@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/react-placeholder/-/react-placeholder-3.0.1.tgz#fa6e915f41ce8da66eb10a4aa6d87d31e50aeaaa"
@@ -9462,6 +9498,11 @@ regenerate@^1.2.1, regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+  integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
@@ -11321,7 +11362,7 @@ whatwg-mimetype@^2.1.0:
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz#a3d58ef10b76009b042d03e25591ece89b88d171"
   integrity sha512-5YSO1nMd5D1hY3WzAQV3PzZL83W3YeyR1yW9PcH26Weh1t+Vzh9B6XkDh7aXm83HBZ4nSMvkjvN2H2ySWIvBgw==
 
-whatwg-url@^6.4.1:
+whatwg-url@^6.4.1, whatwg-url@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
   integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==


### PR DESCRIPTION
## What does this PR do?
- Adds Pagination Support to article Landing Page.

## Description of Task to be completed?
- The user can easily navigate to previous articles using pagination.

## How should this be manually tested?
Clone the repo, cd into ah-leagueoflegends-frontend. Run **npm install** or **yarn add**. Then run yarn start.
- Start your Django backend server.
- Open the home page on your browser.
- Login
- Navigate to the home page and scroll down to navigate to previous articles.


## What are the relevant pivotal tracker stories?
[#159965445](https://www.pivotaltracker.com/story/show/159965445)

## Screenshot.
### Landing Page with pagination support.
<img width="1402" alt="screen shot 2018-10-26 at 12 20 20" src="https://user-images.githubusercontent.com/39088834/47557529-96126d80-d919-11e8-89e1-272ef44ee6c2.png">




