### PR TITLE
#159965460 Enable like and dislike of comments

### DIFF
--- a/src/components/LikeDislike/index.js
+++ b/src/components/LikeDislike/index.js
@@ -15,6 +15,7 @@ class LikeDislike extends Component {
     this.handleLikeDislike = this.handleLikeDislike.bind(this);
   }
 
+
   handleLikeDislike(isLike) {
     if (localStorage.getItem('access_token')) {
       const { like, dislike, mainArticle } = this.props;

--- a/src/components/LikeDislikeComments/index.js
+++ b/src/components/LikeDislikeComments/index.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react';
+// eslint-disable-next-line
+import '../../styles/scss/components/_likeDislikeArticles.scss';
+
+class LikeDislikeComments extends Component {
+  render() {
+    return (
+      <div>
+        <button
+          className="btn-thumb-up"
+          type="submit"
+          onClick={() => this.handleLikeDislike(true)}
+        >
+          <i className="material-icons" id="like">thumb_up</i>
+        </button>
+        <button
+          type="submit"
+          className="btn-thumb-down"
+          onClick={() => this.handleLikeDislike(false)}
+        >
+          <i className="material-icons" id="dislike">thumb_down</i>
+        </button>
+      </div>
+    );
+  }
+}
+
+
+export default LikeDislikeComments;

--- a/src/components/LikeDislikeComments/index.js
+++ b/src/components/LikeDislikeComments/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import toastr from 'toastr';
 
 import { dislikeComments, likeComments } from '../../containers/LikeDislikeComments/actions';
@@ -68,7 +69,11 @@ const mapStateToProps = state => (
     likeDislikeCommentReducer: state.likeDislikeCommentReducer,
   });
 
-export default connect(mapStateToProps, {
-  dislike: dislikeComments,
-  like: likeComments,
-})(LikeDislikeComments);
+const mapDispatchToProps = dispatch => bindActionCreators(
+  {
+    dislike: dislikeComments,
+    like: likeComments,
+  },
+  dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(LikeDislikeComments);

--- a/src/components/LikeDislikeComments/index.js
+++ b/src/components/LikeDislikeComments/index.js
@@ -1,29 +1,74 @@
 import React, { Component } from 'react';
-// eslint-disable-next-line
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import toastr from 'toastr';
+
+import { dislikeComments, likeComments } from '../../containers/LikeDislikeComments/actions';
+
 import '../../styles/scss/components/_likeDislikeArticles.scss';
 
 class LikeDislikeComments extends Component {
+  constructor(props) {
+    super(props);
+    this.handleLikeDislikeComment = this.handleLikeDislikeComment.bind(this);
+  }
+
+  handleLikeDislikeComment(isLike) {
+    if (localStorage.getItem('access_token')) {
+      const { like, dislike, mainArticle } = this.props;
+      const { slug } = mainArticle.payload;
+      const { id } = this.props;
+      if (isLike) {
+        like(slug, id);
+      } else {
+        dislike(slug, id);
+      }
+    } else {
+      toastr.error('Please Login/Register.');
+    }
+  }
+
   render() {
+    const { likes, dislikes } = this.props;
     return (
       <div>
         <button
           className="btn-thumb-up"
           type="submit"
-          onClick={() => this.handleLikeDislike(true)}
+          onClick={() => this.handleLikeDislikeComment(true)}
         >
           <i className="material-icons" id="like">thumb_up</i>
+          <span>{likes}</span>
         </button>
         <button
           type="submit"
           className="btn-thumb-down"
-          onClick={() => this.handleLikeDislike(false)}
+          onClick={() => this.handleLikeDislikeComment(false)}
         >
           <i className="material-icons" id="dislike">thumb_down</i>
+          <span>{dislikes}</span>
         </button>
       </div>
     );
   }
 }
 
+LikeDislikeComments.propTypes = {
+  like: PropTypes.func.isRequired,
+  dislike: PropTypes.func.isRequired,
+  id: PropTypes.number.isRequired,
+  mainArticle: PropTypes.shape().isRequired,
+  likes: PropTypes.number.isRequired,
+  dislikes: PropTypes.number.isRequired,
+};
 
-export default LikeDislikeComments;
+const mapStateToProps = state => (
+  {
+    mainArticle: state.completeArticle,
+    likeDislikeCommentReducer: state.likeDislikeCommentReducer,
+  });
+
+export default connect(mapStateToProps, {
+  dislike: dislikeComments,
+  like: likeComments,
+})(LikeDislikeComments);

--- a/src/containers/LikeDislikeComments/actions.js
+++ b/src/containers/LikeDislikeComments/actions.js
@@ -1,0 +1,52 @@
+import axios from 'axios';
+import { BACKEND_URL } from '../../utils/config';
+import getComments from '../comments/getComents/actions';
+
+export const LIKE_COMMENT = 'LIKE_COMMENT';
+export const DISLIKE_COMMENT = 'DISLIKE_COMMENT';
+export const LIKE_DISLIKE_FAILURE = 'LIKE_DISLIKE_FAILURE';
+
+export const likeComment = () => ({ type: LIKE_COMMENT });
+
+export const dislikeComment = () => ({ type: DISLIKE_COMMENT });
+
+export const likeDislikeCommentFailure = errors => ({
+  type: LIKE_DISLIKE_FAILURE,
+  errors,
+});
+
+// like a comment
+export const likeComments = (slug, id) => {
+  const token = localStorage.getItem('access_token');
+  axios.defaults.headers.common.Authorization = `Bearer ${token}`;
+  const url = `${BACKEND_URL}api/articles/${slug}/comments/${id}/like`;
+  return (dispatch) => {
+    dispatch(likeComment());
+    return axios.put(url)
+      .then(() => {
+        dispatch(getComments(slug, id));
+      })
+      .catch((err) => {
+        dispatch(likeDislikeCommentFailure(err));
+      },
+      );
+  };
+};
+
+// dislike a comment
+export const dislikeComments = (slug, id) => {
+  const url = `${BACKEND_URL}api/articles/${slug}/comments/${id}/dislike`;
+  const token = localStorage.getItem('access_token');
+  axios.defaults.headers.common.Authorization = `Bearer ${token}`;
+  return (dispatch) => {
+    dispatch(dislikeComment());
+    return axios.put(url)
+      .then(() => {
+        dispatch(getComments(slug, id));
+      })
+      .catch((err) => {
+        dispatch(likeDislikeCommentFailure(err));
+      },
+      );
+  };
+};

--- a/src/containers/LikeDislikeComments/actions.test.js
+++ b/src/containers/LikeDislikeComments/actions.test.js
@@ -1,0 +1,35 @@
+import * as actions from './actions';
+
+export const LIKE_COMMENT = 'LIKE_COMMENT';
+export const DISLIKE_COMMENT = 'DISLIKE_COMMENT';
+export const LIKE_DISLIKE_FAILURE = 'LIKE_DISLIKE_FAILURE';
+
+
+describe('Actions for likeDislike comments', () => {
+  // Like articles
+  it('should do an like comment action', () => {
+    const expectedAction = { type: LIKE_COMMENT };
+    expect(actions.likeComment()).toEqual(expectedAction);
+  });
+
+  // Dislike articles
+  it('should do an dislike comment action', () => {
+    const expectedAction = { type: DISLIKE_COMMENT };
+    expect(actions.dislikeComment()).toEqual(expectedAction);
+  });
+
+  // Dispatch error when likeDislike article fails
+  it('should dispatch errors when likeDislike fails', () => {
+    const errors = {
+      errors: {
+        error:
+          ['Authentication credentials were not provided.'],
+      },
+    };
+    const expectedAction = {
+      type: LIKE_DISLIKE_FAILURE,
+      errors,
+    };
+    expect(actions.likeDislikeCommentFailure(errors)).toEqual(expectedAction);
+  });
+});

--- a/src/containers/LikeDislikeComments/reducer.js
+++ b/src/containers/LikeDislikeComments/reducer.js
@@ -1,0 +1,36 @@
+import { DISLIKE_COMMENT, LIKE_COMMENT, LIKE_DISLIKE_FAILURE } from './actions';
+
+const initialState = {
+  error: {},
+  isLiking: false,
+  isDisliking: false,
+};
+
+const likeDislikeCommentReducer = (state = initialState, action) => {
+  const { type, errors } = action;
+  switch (type) {
+    case LIKE_COMMENT:
+      return {
+        ...state,
+        isLiking: true,
+        isDisliking: false,
+      };
+    case DISLIKE_COMMENT:
+      return {
+        ...state,
+        isDisliking: true,
+        isLiking: false,
+      };
+    case LIKE_DISLIKE_FAILURE:
+      return {
+        ...state,
+        isDisliking: false,
+        isLiking: false,
+        errors,
+      };
+    default:
+      return state;
+  }
+};
+
+export default likeDislikeCommentReducer;

--- a/src/containers/LikeDislikeComments/reducer.test.js
+++ b/src/containers/LikeDislikeComments/reducer.test.js
@@ -1,0 +1,64 @@
+import * as actions from './actions';
+import likeDislikeCommentReducer from './reducer';
+
+describe('likeDislikeComment reducers', () => {
+  // LIKE_COMMENT
+  it('should set isLiking to true', () => {
+    const initialState = {
+      error: {},
+      isLiking: false,
+      isDisliking: false,
+    };
+    const action = actions.likeComment();
+
+    const newState = likeDislikeCommentReducer(initialState, action);
+    // tests the number of objects returned == 3
+    expect(Object.keys(newState).length).toEqual(3);
+    // test if isLiking: true,
+    expect(newState.isLiking).toBe(true);
+    // test if isDisliking: false,
+    expect(newState.isDisliking).toBe(false);
+  });
+
+  // LIKE_DISLIKE_FAILURE
+  it('should set isDisliking and isLiking to False', () => {
+    const initialState = {
+      error: {},
+      isLiking: false,
+      isDisliking: false,
+    };
+    const errors = {
+      errors: {
+        error:
+          ['Authentication credentials were not provided.'],
+      },
+    };
+    const action = actions.likeDislikeCommentFailure(errors);
+
+    const newState = likeDislikeCommentReducer(initialState, action);
+    // tests the number of objects returned == 3
+    expect(Object.keys(newState).length).toEqual(4);
+    // test if isLiking: false,
+    expect(newState.isLiking).toBe(false);
+    // test ifisDisliking: false,
+    expect(newState.isDisliking).toBe(false);
+  });
+
+  // DISLIKE_COMMENT
+  it('should set isDisliking to true', () => {
+    const initialState = {
+      error: {},
+      isLiking: false,
+      isDisliking: false,
+    };
+    const action = actions.dislikeComment();
+
+    const newState = likeDislikeCommentReducer(initialState, action);
+    // tests the number of objects returned == 3
+    expect(Object.keys(newState).length).toEqual(3);
+    // test if isLiking: false,
+    expect(newState.isLiking).toBe(false);
+    // test if isDisliking: true,
+    expect(newState.isDisliking).toBe(true);
+  });
+});

--- a/src/containers/comments/getComents/comments.js
+++ b/src/containers/comments/getComents/comments.js
@@ -67,7 +67,8 @@ class CommentsComponent extends Component {
               { comments.body }
               <br />
               <br />
-              <LikeDislikeComments />
+              {/* eslint-disable-next-line */}
+              <LikeDislikeComments id={this.props.comments.id} likes={this.props.comments.likes} dislikes={this.props.comments.dislikes} />
             </div>
           )
         }

--- a/src/containers/comments/getComents/comments.js
+++ b/src/containers/comments/getComents/comments.js
@@ -5,6 +5,7 @@ import { bindActionCreators } from 'redux';
 
 import publishComment from '../actions';
 import getComents from './actions';
+import LikeDislikeComments from '../../../components/LikeDislikeComments';
 
 class CommentsComponent extends Component {
   state = {
@@ -61,7 +62,14 @@ class CommentsComponent extends Component {
                 edit
               </button>
             </div>)
-          : <div>{ comments.body }</div>
+          : (
+            <div>
+              { comments.body }
+              <br />
+              <br />
+              <LikeDislikeComments />
+            </div>
+          )
         }
       </div>
     );

--- a/src/store/rootReducer.js
+++ b/src/store/rootReducer.js
@@ -17,6 +17,7 @@ import { SocialLoginReducer } from '../components/Authentication/Login/socialLog
 import NotificationReducer from '../containers/Notification/reducer';
 import viewProfileReducer from '../containers/Profile/ViewProfile/reducer';
 import editProfileReducer from '../containers/Profile/UpdateProfile/reducer';
+import likeDislikeCommentReducer from '../containers/LikeDislikeComments/reducer';
 
 import toggleNotificationReducer from '../containers/ToggleNotifications/reducer';
 
@@ -38,4 +39,5 @@ export default combineReducers({
   editProfileReducer,
   viewProfileReducer,
   toggleNotificationReducer,
+  likeDislikeCommentReducer,
 });


### PR DESCRIPTION
## What does this PR do?
```
This PR enables authenticated users to like, dislike and have a neutral state towards comments to articles.

```

## Description of Task to be completed?
```
Create the like and dislike components.
Implement the like and dislike functionalities.

```

## How should this be manually tested?

```
Clone the repo, cd into ah-leagueoflegends-frontend. Run npm install or yarn add. Then run yarn start.
Open the home page on your browser.
Navigate to of the articles and view the comments.
After that, click the like and dislike icons and observe.



```
## What are the relevant pivotal tracker stories?

[#159965460](https://www.pivotaltracker.com/n/projects/2192365)


## Screenshots if available to support PR.

<img width="1280" alt="screen shot 2018-10-26 at 14 29 28" src="https://user-images.githubusercontent.com/39087913/47563910-f3171f00-d92b-11e8-95af-b3c5180f5b03.png">

## Like and Dislike
<img width="1280" alt="screenshot 2018-11-01 at 17 53 18" src="https://user-images.githubusercontent.com/39087913/47859371-3aefe780-ddff-11e8-8f7f-f96fcda44875.png">

## Neutral state
<img width="735" alt="screenshot 2018-11-01 at 17 54 14" src="https://user-images.githubusercontent.com/39087913/47859399-4f33e480-ddff-11e8-9512-dac0db942965.png">


## Questions:

```
Do you have any views?

```
