### PR TITLE
#159965443 Fix rating error when creating a new article. Fix rating error message.

### DIFF
--- a/src/components/Rating/Rating.js
+++ b/src/components/Rating/Rating.js
@@ -7,7 +7,6 @@ import M from 'materialize-css';
 import { rateArticle, AverageRate } from './actions/actions';
 
 class Rating extends Component {
-
   async componentDidMount() {
     // eslint-disable-next-line
     if (this.props.slug !== undefined) await this.props.AverageRate(this.props.slug);
@@ -17,10 +16,6 @@ class Rating extends Component {
     // eslint-disable-next-line
     this.props.rateArticle(this.props.slug, nextValue);
   };
-
-  // showError = (err) => {
-  //   M.toast({ html: err, classes: 'red' });
-  // };
 
   render() {
     return (

--- a/src/components/Rating/Rating.js
+++ b/src/components/Rating/Rating.js
@@ -18,18 +18,13 @@ class Rating extends Component {
     this.props.rateArticle(this.props.slug, nextValue);
   };
 
-  showError = (err) => {
-    M.toast({ html: err, classes: 'red' });
-  };
+  // showError = (err) => {
+  //   M.toast({ html: err, classes: 'red' });
+  // };
 
   render() {
-    const { ratingReducer } = this.props;
     return (
       <React.Fragment>
-        <div className="errorMessage">
-          {ratingReducer.ratingError && this.showError(ratingReducer.ratingError)}
-        </div>
-
         <div className="row" style={{ centerContent: 'flex-end', marginLeft: '20%' }}>
           <div className="col s12 m6">
             <div>

--- a/src/components/Rating/actions/actions.js
+++ b/src/components/Rating/actions/actions.js
@@ -11,12 +11,12 @@ export const rateAction = rate => ({
 // action creator: takes a response and returns type CURRENT_RATE
 export const currentRate = response => ({
   type: CURRENT_RATE,
-  payload: { userRating: response === undefined ? 0 : response },
+  payload: { userRating: response === null ? 0 : response },
 });
 // action creator: takes response and returns type CURRENT_AVG
 export const currentAVG = response => ({
   type: CURRENT_AVG,
-  payload: { average_rating: response === undefined ? 0 : response },
+  payload: { average_rating: response === null ? 0 : response },
 });
 // action creator: takes an err and returns type RATING_FAILURE
 export const ratingError = err => ({


### PR DESCRIPTION
## What does this PR do?
```
Fix rating error when a new article is created. The average rating and initial rating need to be zero(null).
```

## Description of Task to be completed?
```
When a new article is created the rating has to be zero as there is no rating for it at that time.

```

## How should this be manually tested?

```
Clone the repo ah-leagueOfLegends-frontend. cd into ah-leagueOfLegends-frontend and run npm install. Sign up if you do not have an account and sign in if you have an account. On the home page, click on read more. Rate an article by clicking on any number of stars.
```
## Any background context you want to provide?

```
Rating functionality raised an error when a new article is created. It was working for older articles.

```

## What are the relevant pivotal tracker stories?

[#159965443](https://www.pivotaltracker.com/story/show/159965443


## Screenshots if available to support PR.
<img width="760" alt="screen shot 2018-10-31 at 15 40 01" src="https://user-images.githubusercontent.com/39365725/47793671-dc0f6d00-dd2f-11e8-8560-621bb0f6c018.png">


